### PR TITLE
Fix recurring frontend warnings in ChatBox and disable Vite auto-open

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # 🧠 AI Agent Platform
 
-Višenamjenska AI platforma inspirisana Manus.im, sa modularnim agentima, vizualnim prikazom toka rada, i moćnim interaktivnim UI-jem.
+Višenamjenska AI platforma inspirisana Manus.im, sa modularnim agentima, vizualnim prikazom toka rada i autonomnim sandbox izvršavanjem (kod + shell komande).
 
 ---
 
 ## ✅ Funkcionalnosti
 
-- **Modularni backend agenti**: `Executor`, `Code`, `Planner`, `Data`
-- **OpenAI integracija**: koristi `gpt-4`, `temperature`, `max_tokens`, `system_prompt` konfiguraciju po agentu
-- **Automatski chunking** velikih inputa
+- **Modularni backend agenti**: `Executor`, `Code`, `Planner`, `Data`, `Debugger`
+- **Autonomni režim**: orkestracija `Executor -> Planner -> specijalizovani agenti -> Executor sažetak`
+- **Sandbox izvršavanje koda** (Python/JavaScript) sa timeout i resource limitima
+- **Sandbox shell komande** (`bash`) u izolovanom workspace-u
+- **Persistent sandbox workspace** za višekoračne zadatke (build/test/fix ciklus)
+- **OpenAI + Anthropic MCP podrška**
 - **Vizualni prikaz toka rada agenata** pomoću `React Flow`
 - **Radno okruženje** (terminal / code / web view) za prikaz rezultata
 - **Session Explorer**: prikaz svih koraka agenata
@@ -18,33 +21,25 @@ Višenamjenska AI platforma inspirisana Manus.im, sa modularnim agentima, vizual
 
 ## 📁 Struktura projekta
 
-```
+```text
 .
 ├── backend/
 │   ├── agents/
-│   │   ├── executor_agent.py
-│   │   ├── code_agent.py
-│   │   ├── planner_agent.py
-│   │   └── data_agent.py
 │   ├── config/
-│   │   └── agents_config.json
-│   ├── utils/
-│   │   ├── chunker.py
-│   │   └── session_store.py
+│   ├── endpoints/
 │   ├── schemas/
-│   │   └── chat.py
-│   └── .env
+│   ├── utils/
+│   └── main.py
 ├── frontend/
 │   └── src/
 │       ├── App.jsx
 │       ├── api.js
 │       └── components/
 │           ├── ChatBox.jsx
-│           ├── Sidebar.jsx
 │           ├── TaskFlow.jsx
 │           ├── WorkEnvironment.jsx
 │           └── SessionExplorer.jsx
-└── requirements.txt
+└── README.md
 ```
 
 ---
@@ -56,12 +51,10 @@ Višenamjenska AI platforma inspirisana Manus.im, sa modularnim agentima, vizual
 ```bash
 cd backend
 pip install -r requirements.txt
-uvicorn main:app --reload
+uvicorn main:app --reload --port 8080
 ```
 
-- API endpoint: `POST /chat` prima `{"message": "...", "agent": "executor"}`
-
-### 2. Frontend (React + Tailwind)
+### 2. Frontend (React + Vite)
 
 ```bash
 cd frontend
@@ -69,67 +62,106 @@ npm install
 npm run dev
 ```
 
-Otvorite [http://localhost:5173](http://localhost:5173)
+Otvori: [http://localhost:5173](http://localhost:5173)
 
 ---
 
-## ⚙️ Konfiguracija agenata (`agents_config.json`)
+## 🔌 Glavni API endpointi
+
+### Chat i workflow
+
+- `POST /chat`
+  - primjer body:
 
 ```json
 {
-  "code": {
-    "model": "gpt-4",
-    "temperature": 0.5,
-    "max_tokens": 1500,
-    "system_prompt": "You are a coding assistant."
-  },
-  "planner": {
-    "model": "gpt-4",
-    "temperature": 0.7,
-    "max_tokens": 1000,
-    "system_prompt": "You are a planning assistant."
-  },
-  "data": {
-    "model": "gpt-4",
-    "temperature": 0.6,
-    "max_tokens": 1200,
-    "system_prompt": "You are a data assistant."
+  "message": "Napravi TODO app i pokreni testove",
+  "agent": "executor",
+  "auto_process": false,
+  "model": "default",
+  "temperature": 0.7,
+  "mcp_server": "anthropic"
+}
+```
+
+### Izvršavanje koda (sandbox)
+
+- `POST /execute-code`
+  - podržava `python`, `javascript`, `html`
+  - opcije: `sandbox`, `timeout_seconds`, `auto_debug`
+
+```json
+{
+  "code": "print('hello')",
+  "language": "python",
+  "mode": "script",
+  "sandbox": true,
+  "timeout_seconds": 8,
+  "auto_debug": true
+}
+```
+
+### Izvršavanje shell komandi u sandboxu
+
+- `POST /execute-command-sandbox`
+  - izvršava komandu preko `bash -lc` u izolovanom direktoriju
+  - podržava:
+    - `files` (pre-populate fajlova)
+    - `persist_workspace` + `workspace_id` (nastavak rada kroz više komandi)
+
+```json
+{
+  "command": "npm test",
+  "timeout_seconds": 20,
+  "sandbox": true,
+  "persist_workspace": true,
+  "workspace_id": null,
+  "files": {
+    "package.json": "{\"name\":\"demo\",\"scripts\":{\"test\":\"echo ok\"}}"
   }
 }
 ```
 
----
-
-## 🔁 Interaktivni tok rada
-
-1. Unesi poruku u ChatBox
-2. Executor delegira zadatak odgovarajućem agentu
-3. Agent obradi i odgovori
-4. TaskFlow prikazuje dijagram toka
-5. Klikni na čvor → vidi odgovor + ponovi rad
-6. Uredi prompt i uporedi razlike (diff)
+- `DELETE /sandbox-workspace/{workspace_id}`
+  - ručno čišćenje persistent workspace-a
 
 ---
 
-## 📦 TODO / buduće opcije
+## 🤖 Autonomni režim (frontend)
 
-- Upload CSV/PDF fajlova i vizualizacija
-- RAG agent za rad sa dokumentima
-- Višekorisnički sistem (login + tokeni)
-- Export sesije u PDF/JSON
-- Podrška za više različitih LLM pružalaca usluga (Claude, Mistral, Llama, itd.)
-- Sistem za automatsko testiranje ponašanja agenata i validaciju rezultata
-- Implementacija "pamćenja" agenata između sesija (kontinuitet razgovora)
-- Metrike performansi agenata i vizualni dashboard za analitiku
+U `ChatBox` postoji toggle **Autonomni režim**:
+
+1. korisnik pošalje cilj
+2. `Executor` interpretira zadatak
+3. `Planner` generiše korake
+4. `Code/Data` agenti rješavaju korake
+5. ako odgovor sadrži fenced shell blok (```bash ... ```), komanda se izvršava u sandboxu
+6. `Executor` vrati završni sažetak
+
+Napomena: autonomni workflow automatski clean-up-a workspace na kraju toka.
+
+---
+
+## 🔒 Sigurnosne napomene
+
+- Sandbox ovdje je **lightweight process isolation** (timeout + rlimits + temp workspace), nije full VM-level izolacija.
+- Za produkciju preporučeno:
+  - odvojeni worker/container runtime
+  - network egress restrikcije
+  - seccomp/apparmor profile
+  - per-user quota i audit log
+
+---
+
+## 📦 Roadmap
+
+- Session-bound persistent workspace kroz cijelu korisničku sesiju
+- Snapshot/restore sandbox stanja
+- Vizualni prikaz shell koraka i izlaza u TaskFlow
+- Sigurnosna politika po tenant-u (RBAC + resource budget)
 
 ---
 
 ## 🧠 Vizija
 
-> “Ne pravimo samo chat — pravimo alat koji **radi s tobom**, razumije tok posla, pamti tvoje korake, i pomaže kao pravi digitalni inženjer.”
-
----
-
-## 🧑‍💻 Autor: [Tvoj Projekat — Agent Sistem za Sve]
-
-> Inspiriše te Manus? Onda je ovo tvoj prvi korak ka nečemu još moćnijem.
+> “Ne pravimo samo chat — pravimo alat koji radi s tobom, izvršava korake autonomno i pouzdano u izolovanom okruženju.”

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,7 +12,7 @@ import traceback
 import subprocess
 import tempfile
 import base64
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any
 from pydantic import BaseModel
 
 # Dodaj glavni direktorij u sys.path
@@ -79,6 +79,8 @@ app.include_router(anthropic_router)
 app.include_router(openai_router)
 
 # Mapiraj agente za direktno usmjeravanje
+SANDBOX_WORKSPACES: Dict[str, str] = {}
+
 agent_map = {
     "executor": executor_agent,
     "code": code_agent,
@@ -112,12 +114,15 @@ class SandboxCommandRequest(BaseModel):
     timeout_seconds: Optional[int] = 15
     sandbox: Optional[bool] = True
     files: Optional[Dict[str, str]] = None
+    workspace_id: Optional[str] = None
+    persist_workspace: Optional[bool] = False
 
 class SandboxCommandResponse(BaseModel):
     stdout: str
     stderr: str
     exit_code: int
     status: str
+    workspace_id: Optional[str] = None
 
 # Prošireni model za chat upit s auto_process
 class ChatRequestExtended(ChatRequest):
@@ -402,59 +407,103 @@ async def execute_command_sandbox(request: SandboxCommandRequest):
         except Exception:
             pass
 
+    workspace_id = request.workspace_id
+    workspace_dir = None
+    ephemeral_dir = None
+
     try:
-        with tempfile.TemporaryDirectory(prefix="agent_shell_sandbox_") as sandbox_dir:
-            if request.files:
-                for rel_path, content in request.files.items():
-                    normalized = os.path.normpath(rel_path).lstrip("/")
-                    abs_path = os.path.abspath(os.path.join(sandbox_dir, normalized))
-                    if not abs_path.startswith(os.path.abspath(sandbox_dir)):
-                        return {
-                            "stdout": "",
-                            "stderr": f"Nedozvoljena putanja: {rel_path}",
-                            "exit_code": 1,
-                            "status": "error"
-                        }
-                    os.makedirs(os.path.dirname(abs_path), exist_ok=True)
-                    with open(abs_path, "w", encoding="utf-8") as f:
-                        f.write(content)
+        if request.persist_workspace:
+            if workspace_id:
+                workspace_dir = SANDBOX_WORKSPACES.get(workspace_id)
+                if not workspace_dir:
+                    return {
+                        "stdout": "",
+                        "stderr": f"Workspace ne postoji: {workspace_id}",
+                        "exit_code": 1,
+                        "status": "error",
+                        "workspace_id": workspace_id
+                    }
+            else:
+                workspace_id = str(uuid.uuid4())
+                workspace_dir = tempfile.mkdtemp(prefix="agent_shell_workspace_")
+                SANDBOX_WORKSPACES[workspace_id] = workspace_dir
+        else:
+            ephemeral_dir = tempfile.TemporaryDirectory(prefix="agent_shell_sandbox_")
+            workspace_dir = ephemeral_dir.name
 
-            env = {
-                "PATH": os.environ.get("PATH", ""),
-                "HOME": sandbox_dir,
-                "TMPDIR": sandbox_dir,
-            }
+        if request.files:
+            for rel_path, content in request.files.items():
+                normalized = os.path.normpath(rel_path).lstrip("/")
+                abs_path = os.path.abspath(os.path.join(workspace_dir, normalized))
+                if not abs_path.startswith(os.path.abspath(workspace_dir)):
+                    return {
+                        "stdout": "",
+                        "stderr": f"Nedozvoljena putanja: {rel_path}",
+                        "exit_code": 1,
+                        "status": "error",
+                        "workspace_id": workspace_id
+                    }
+                os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+                with open(abs_path, "w", encoding="utf-8") as f:
+                    f.write(content)
 
-            completed = subprocess.run(
-                ["bash", "-lc", request.command],
-                cwd=sandbox_dir,
-                capture_output=True,
-                text=True,
-                timeout=timeout_seconds,
-                env=env,
-                preexec_fn=_sandbox_preexec if request.sandbox else None
-            )
+        env = {
+            "PATH": os.environ.get("PATH", ""),
+            "HOME": workspace_dir,
+            "TMPDIR": workspace_dir,
+        }
 
-            return {
-                "stdout": completed.stdout,
-                "stderr": completed.stderr,
-                "exit_code": completed.returncode,
-                "status": "success" if completed.returncode == 0 else "error"
-            }
+        completed = subprocess.run(
+            ["bash", "-lc", request.command],
+            cwd=workspace_dir,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            env=env,
+            preexec_fn=_sandbox_preexec if request.sandbox else None
+        )
+
+        return {
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+            "exit_code": completed.returncode,
+            "status": "success" if completed.returncode == 0 else "error",
+            "workspace_id": workspace_id
+        }
     except subprocess.TimeoutExpired:
         return {
             "stdout": "",
             "stderr": f"Command timeout after {timeout_seconds}s",
             "exit_code": 124,
-            "status": "error"
+            "status": "error",
+            "workspace_id": workspace_id
         }
     except Exception as e:
         return {
             "stdout": "",
             "stderr": str(e),
             "exit_code": 1,
-            "status": "error"
+            "status": "error",
+            "workspace_id": workspace_id
         }
+    finally:
+        if ephemeral_dir:
+            ephemeral_dir.cleanup()
+
+
+@app.delete("/sandbox-workspace/{workspace_id}")
+async def cleanup_sandbox_workspace(workspace_id: str):
+    workspace_dir = SANDBOX_WORKSPACES.pop(workspace_id, None)
+    if not workspace_dir:
+        raise HTTPException(status_code=404, detail=f"Workspace ne postoji: {workspace_id}")
+
+    try:
+        import shutil
+        shutil.rmtree(workspace_dir, ignore_errors=True)
+    except Exception:
+        pass
+
+    return {"status": "deleted", "workspace_id": workspace_id}
 
 @app.get("/sessions")
 async def list_sessions():

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,7 +12,7 @@ import traceback
 import subprocess
 import tempfile
 import base64
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 from pydantic import BaseModel
 
 # Dodaj glavni direktorij u sys.path
@@ -104,6 +104,19 @@ class CodeExecutionResponse(BaseModel):
     output: str
     error: Optional[str] = None
     imageBase64: Optional[str] = None
+    status: str
+
+
+class SandboxCommandRequest(BaseModel):
+    command: str
+    timeout_seconds: Optional[int] = 15
+    sandbox: Optional[bool] = True
+    files: Optional[Dict[str, str]] = None
+
+class SandboxCommandResponse(BaseModel):
+    stdout: str
+    stderr: str
+    exit_code: int
     status: str
 
 # Prošireni model za chat upit s auto_process
@@ -370,6 +383,78 @@ GREŠKA:
         result["status"] = "error"
 
     return result
+
+
+@app.post("/execute-command-sandbox", response_model=SandboxCommandResponse)
+async def execute_command_sandbox(request: SandboxCommandRequest):
+    timeout_seconds = max(1, min(request.timeout_seconds or 15, 60))
+
+    def _sandbox_preexec():
+        if os.name != "posix":
+            return
+        try:
+            import resource
+            resource.setrlimit(resource.RLIMIT_CPU, (timeout_seconds, timeout_seconds + 1))
+            resource.setrlimit(resource.RLIMIT_AS, (1024 * 1024 * 1024, 1024 * 1024 * 1024))
+            resource.setrlimit(resource.RLIMIT_FSIZE, (10 * 1024 * 1024, 10 * 1024 * 1024))
+            resource.setrlimit(resource.RLIMIT_NOFILE, (128, 128))
+            resource.setrlimit(resource.RLIMIT_NPROC, (64, 64))
+        except Exception:
+            pass
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="agent_shell_sandbox_") as sandbox_dir:
+            if request.files:
+                for rel_path, content in request.files.items():
+                    normalized = os.path.normpath(rel_path).lstrip("/")
+                    abs_path = os.path.abspath(os.path.join(sandbox_dir, normalized))
+                    if not abs_path.startswith(os.path.abspath(sandbox_dir)):
+                        return {
+                            "stdout": "",
+                            "stderr": f"Nedozvoljena putanja: {rel_path}",
+                            "exit_code": 1,
+                            "status": "error"
+                        }
+                    os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+                    with open(abs_path, "w", encoding="utf-8") as f:
+                        f.write(content)
+
+            env = {
+                "PATH": os.environ.get("PATH", ""),
+                "HOME": sandbox_dir,
+                "TMPDIR": sandbox_dir,
+            }
+
+            completed = subprocess.run(
+                ["bash", "-lc", request.command],
+                cwd=sandbox_dir,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                env=env,
+                preexec_fn=_sandbox_preexec if request.sandbox else None
+            )
+
+            return {
+                "stdout": completed.stdout,
+                "stderr": completed.stderr,
+                "exit_code": completed.returncode,
+                "status": "success" if completed.returncode == 0 else "error"
+            }
+    except subprocess.TimeoutExpired:
+        return {
+            "stdout": "",
+            "stderr": f"Command timeout after {timeout_seconds}s",
+            "exit_code": 124,
+            "status": "error"
+        }
+    except Exception as e:
+        return {
+            "stdout": "",
+            "stderr": str(e),
+            "exit_code": 1,
+            "status": "error"
+        }
 
 @app.get("/sessions")
 async def list_sessions():

--- a/backend/main.py
+++ b/backend/main.py
@@ -97,6 +97,8 @@ class CodeExecutionRequest(BaseModel):
     auto_debug: Optional[bool] = False
     mcp_server: Optional[str] = "anthropic"
     auto_model_selection: Optional[bool] = False
+    sandbox: Optional[bool] = True
+    timeout_seconds: Optional[int] = 8
 
 class CodeExecutionResponse(BaseModel):
     output: str
@@ -111,6 +113,8 @@ class ChatRequestExtended(ChatRequest):
     temperature: Optional[float] = 0.7
     mcp_server: Optional[str] = "anthropic"
     auto_model_selection: Optional[bool] = False
+    sandbox: Optional[bool] = True
+    timeout_seconds: Optional[int] = 8
 
 @app.post("/chat")
 async def chat_endpoint(request: ChatRequestExtended):
@@ -201,86 +205,124 @@ async def chat_endpoint(request: ChatRequestExtended):
 @app.post("/execute-code", response_model=CodeExecutionResponse)
 async def execute_code(request: CodeExecutionRequest):
     """
-    Stvarno izvršava kod i vraća rezultat.
+    Izvršava kod u izoliranom privremenom direktoriju (sandbox-lite) i vraća rezultat.
     Podržava Python, JavaScript i HTML.
     """
-    
+
     result = {
         "output": "",
         "error": None,
         "imageBase64": None,
         "status": "success"
     }
-    
-    # Provjeri da li treba automatski odabrati model za debug
+
     mcp_server = request.mcp_server
     auto_model_selection = request.auto_model_selection
-    
+    timeout_seconds = max(1, min(request.timeout_seconds, 30))
+
+    def _sandbox_preexec():
+        if os.name != "posix":
+            return
+        try:
+            import resource
+            resource.setrlimit(resource.RLIMIT_CPU, (timeout_seconds, timeout_seconds + 1))
+            resource.setrlimit(resource.RLIMIT_AS, (512 * 1024 * 1024, 512 * 1024 * 1024))
+            resource.setrlimit(resource.RLIMIT_FSIZE, (5 * 1024 * 1024, 5 * 1024 * 1024))
+            resource.setrlimit(resource.RLIMIT_NOFILE, (64, 64))
+            resource.setrlimit(resource.RLIMIT_NPROC, (32, 32))
+        except Exception:
+            pass
+
+    def _run_code_subprocess(code: str, command: list[str], suffix: str):
+        with tempfile.TemporaryDirectory(prefix="agent_sandbox_") as sandbox_dir:
+            file_path = os.path.join(sandbox_dir, f"main{suffix}")
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(code)
+
+            env = {
+                "PATH": os.environ.get("PATH", ""),
+                "PYTHONNOUSERSITE": "1",
+                "PYTHONDONTWRITEBYTECODE": "1",
+                "HOME": sandbox_dir,
+                "TMPDIR": sandbox_dir
+            }
+
+            completed = subprocess.run(
+                command + [file_path],
+                capture_output=True,
+                text=True,
+                cwd=sandbox_dir,
+                timeout=timeout_seconds,
+                env=env,
+                preexec_fn=_sandbox_preexec if request.sandbox else None
+            )
+            return completed
+
+    async def _attach_debug_suggestion(lang_label: str):
+        debug_message = f"""Debug ovaj {lang_label} kod i ispravi greške:
+```{request.language}
+{request.code}
+```
+
+GREŠKA:
+{result['error']}"""
+
+        debug_request_data = {
+            "message": debug_message,
+            "agent": "debugger",
+            "auto_process": False,
+            "mcp_server": mcp_server
+        }
+
+        if auto_model_selection:
+            router_result = await mcp_router_agent(debug_request_data)
+            model_rec = router_result.get("model_recommendation", {})
+            debug_request_data["model"] = model_rec.get("model", "default")
+            debug_request_data["temperature"] = model_rec.get("temperature", 0.2)
+
+        debug_request = ChatRequestExtended(**debug_request_data)
+        debug_response = await debugger_agent(debug_request.dict())
+        result["debug_suggestion"] = debug_response["response"]
+        if auto_model_selection:
+            result["debug_model_used"] = debug_request_data.get("model", "default")
+
     try:
-        # Za Python kod
         if request.language.lower() in ["python", "py"]:
             if request.mode == "script":
-                # Izvršavanje običnog Python koda
-                f = io.StringIO()
-                with contextlib.redirect_stdout(f):
-                    try:
-                        exec(request.code)
-                        result["output"] = f.getvalue()
-                    except Exception as e:
-                        result["error"] = str(e) + "\n" + traceback.format_exc()
-                        result["status"] = "error"
-                        
-                        # Automatsko ispravljanje koda ako je zatraženo
-                        if request.auto_debug:
-                            debug_message = f"Debug ovaj Python kod i ispravi greške:\n```python\n{request.code}\n```\n\nGREŠKA:\n{result['error']}"
-                            
-                            debug_request_data = {
-                                "message": debug_message,
-                                "agent": "debugger",
-                                "auto_process": False,
-                                "mcp_server": mcp_server
-                            }
-                            
-                            # Ako je uključen automatski odabir modela, koristi router
-                            if auto_model_selection:
-                                router_result = await mcp_router_agent(debug_request_data)
-                                model_rec = router_result.get("model_recommendation", {})
-                                debug_request_data["model"] = model_rec.get("model", "default")
-                                debug_request_data["temperature"] = model_rec.get("temperature", 0.2)
-                            
-                            debug_request = ChatRequestExtended(**debug_request_data)
-                            debug_response = await debugger_agent(debug_request.dict())
-                            
-                            # Dodaj debug prijedlog u odgovor
-                            result["debug_suggestion"] = debug_response["response"]
-                            if auto_model_selection:
-                                result["debug_model_used"] = debug_request_data.get("model", "default")
-                
+                try:
+                    process = _run_code_subprocess(request.code, ["python"], ".py")
+                    result["output"] = process.stdout
+                    if process.stderr:
+                        result["error"] = process.stderr
+                        result["status"] = "error" if process.returncode != 0 else "success"
+                        if request.auto_debug and process.returncode != 0:
+                            await _attach_debug_suggestion("Python")
+                except subprocess.TimeoutExpired:
+                    result["error"] = f"Execution timeout after {timeout_seconds}s"
+                    result["status"] = "error"
+                except Exception as e:
+                    result["error"] = str(e)
+                    result["status"] = "error"
+
             elif request.mode == "gui":
-                # Za GUI aplikacije pišemo kod u privremeni fajl
                 with tempfile.NamedTemporaryFile(suffix='.py', delete=False) as temp:
                     temp.write(request.code.encode())
                     temp_path = temp.name
-                
+
                 try:
-                    # Pokrenemo Python skriptu u odvojenom procesu
                     process = subprocess.Popen(
                         ["python", temp_path],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                         text=True
                     )
-                    
-                    # Čekamo kratko vrijeme da se GUI pokrene
+
                     import time
                     time.sleep(2)
-                    
-                    # Pokušaj napraviti screenshot (potreban je PIL/Pillow)
+
                     try:
                         from PIL import ImageGrab
                         screenshot = ImageGrab.grab()
-                        
-                        # Konvertiramo u base64 za slanje na frontend
                         buffered = io.BytesIO()
                         screenshot.save(buffered, format="PNG")
                         result["imageBase64"] = base64.b64encode(buffered.getvalue()).decode()
@@ -288,86 +330,45 @@ async def execute_code(request: CodeExecutionRequest):
                         result["error"] = "Screenshot nije moguć - PIL/Pillow nije instaliran"
                     except Exception as e:
                         result["error"] = f"Problem sa screenshotom: {str(e)}"
-                    
-                    # Dohvatimo izlaz procesa
+
                     stdout, stderr = process.communicate(timeout=5)
                     result["output"] = stdout
                     if stderr:
                         result["error"] = stderr
-                    
-                    # Zatvorimo proces
+
                     process.terminate()
                 except Exception as e:
                     result["error"] = str(e)
                     result["status"] = "error"
                 finally:
-                    # Obrišimo privremeni fajl
                     try:
                         os.unlink(temp_path)
                     except:
                         pass
-                
-        # Za JavaScript kod
+
         elif request.language.lower() in ["javascript", "js"]:
-            # JavaScript izvršavanje kroz Node.js
-            with tempfile.NamedTemporaryFile(suffix='.js', delete=False) as temp:
-                temp.write(request.code.encode())
-                temp_path = temp.name
-            
             try:
-                process = subprocess.run(
-                    ["node", temp_path], 
-                    capture_output=True, 
-                    text=True
-                )
+                process = _run_code_subprocess(request.code, ["node"], ".js")
                 result["output"] = process.stdout
                 if process.stderr:
                     result["error"] = process.stderr
                     if process.returncode != 0:
                         result["status"] = "error"
-                        
-                        # Automatsko ispravljanje koda ako je zatraženo
                         if request.auto_debug:
-                            debug_message = f"Debug ovaj JavaScript kod i ispravi greške:\n```javascript\n{request.code}\n```\n\nGREŠKA:\n{result['error']}"
-                            
-                            debug_request_data = {
-                                "message": debug_message,
-                                "agent": "debugger",
-                                "auto_process": False,
-                                "mcp_server": mcp_server
-                            }
-                            
-                            # Ako je uključen automatski odabir modela, koristi router
-                            if auto_model_selection:
-                                router_result = await mcp_router_agent(debug_request_data)
-                                model_rec = router_result.get("model_recommendation", {})
-                                debug_request_data["model"] = model_rec.get("model", "default")
-                                debug_request_data["temperature"] = model_rec.get("temperature", 0.2)
-                            
-                            debug_request = ChatRequestExtended(**debug_request_data)
-                            debug_response = await debugger_agent(debug_request.dict())
-                            
-                            # Dodaj debug prijedlog u odgovor
-                            result["debug_suggestion"] = debug_response["response"]
-                            if auto_model_selection:
-                                result["debug_model_used"] = debug_request_data.get("model", "default")
+                            await _attach_debug_suggestion("JavaScript")
+            except subprocess.TimeoutExpired:
+                result["error"] = f"Execution timeout after {timeout_seconds}s"
+                result["status"] = "error"
             except Exception as e:
                 result["error"] = str(e)
                 result["status"] = "error"
-            finally:
-                try:
-                    os.unlink(temp_path)
-                except:
-                    pass
-                
-        # Za HTML kod
+
         elif request.language.lower() in ["html", "markup"]:
-            # HTML možemo vratiti direktno za prikaz u iframeu
             result["output"] = request.code
     except Exception as e:
         result["error"] = str(e) + "\n" + traceback.format_exc()
         result["status"] = "error"
-    
+
     return result
 
 @app.get("/sessions")

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -71,7 +71,7 @@ export const sendChatMessage = async (message, agent = 'executor', options = {})
 
 // Izvršavanje koda s automatskim ispravljanjem grešaka
 export const executeCode = async (code, language, mode = 'script', sessionId = null, options = {}) => {
-  const { autoDebug = true, mcpServer = 'anthropic' } = options;
+  const { autoDebug = true, mcpServer = 'anthropic', sandbox = true, timeoutSeconds = 8 } = options;
   
   try {
     // Koristi trenutni session ID ili onaj koji je prosljeđen
@@ -90,7 +90,9 @@ export const executeCode = async (code, language, mode = 'script', sessionId = n
         mode,
         sessionId: activeSessionId,
         auto_debug: autoDebug, // Za automatsko pokretanje debug procesa ako se pojavi greška
-        mcp_server: mcpServer
+        mcp_server: mcpServer,
+        sandbox,
+        timeout_seconds: timeoutSeconds
       }),
     });
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -823,3 +823,79 @@ export const getTokenUsageStats = async (sessionId = null) => {
     throw error;
   }
 };
+
+/**
+ * Autonomni ciklus: executor -> planner -> specijalizirani agent(i) -> executor sažetak.
+ * @param {string} message
+ * @param {Object} options
+ * @returns {Promise<Object>}
+ */
+export const executeAutonomousWorkflow = async (message, options = {}) => {
+  const maxSteps = options.maxSteps || 3;
+  const log = [];
+
+  const executorResponse = await sendChatMessage(message, 'executor', { ...options });
+  log.push({
+    agent: 'executor',
+    prompt: message,
+    response: executorResponse.response
+  });
+
+  const plannerPrompt = `Napravi kratak plan (maksimalno ${maxSteps} koraka) za ovaj zadatak. Vrati čistu numerisanu listu koraka.
+
+ZADATAK: ${message}`;
+  const plannerResponse = await sendChatMessage(plannerPrompt, 'planner', { ...options });
+  log.push({
+    agent: 'planner',
+    prompt: plannerPrompt,
+    response: plannerResponse.response
+  });
+
+  const planSteps = plannerResponse.response
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => /^\d+[.)\-]/.test(line) || /^[-*]/.test(line))
+    .slice(0, maxSteps)
+    .map((line) => line.replace(/^\d+[.)\-]\s*/, '').replace(/^[-*]\s*/, ''));
+
+  const normalizedSteps = planSteps.length > 0 ? planSteps : [plannerResponse.response.trim()].filter(Boolean).slice(0, maxSteps);
+
+  for (const step of normalizedSteps) {
+    const lowerStep = step.toLowerCase();
+    const chosenAgent = lowerStep.includes('analiz') || lowerStep.includes('podat') ? 'data' : 'code';
+    const stepPrompt = `Izvrši ovaj korak iz plana i vrati konkretan rezultat.
+
+KORAK: ${step}
+
+ORIGINALNI ZADATAK: ${message}`;
+    const stepResponse = await sendChatMessage(stepPrompt, chosenAgent, { ...options });
+
+    log.push({
+      agent: chosenAgent,
+      prompt: stepPrompt,
+      response: stepResponse.response,
+      plan_step: step
+    });
+  }
+
+  const summaryPrompt = `Na osnovu kompletnog dnevnika rada, vrati finalni odgovor korisniku.
+
+DNEVNIK: ${JSON.stringify(log)}
+
+Originalni upit: ${message}`;
+  const summaryResponse = await sendChatMessage(summaryPrompt, 'executor', { ...options });
+  log.push({
+    agent: 'executor',
+    prompt: summaryPrompt,
+    response: summaryResponse.response,
+    phase: 'summary'
+  });
+
+  return {
+    mode: 'autonomous',
+    original_message: message,
+    plan: normalizedSteps,
+    steps: log,
+    response: summaryResponse.response
+  };
+};

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -826,6 +826,54 @@ export const getTokenUsageStats = async (sessionId = null) => {
   }
 };
 
+
+
+/**
+ * Izvrši shell komandu u backend sandboxu (Ubuntu/bash okruženje unutar temp direktorija).
+ * @param {string} command
+ * @param {Object} options
+ * @returns {Promise<Object>}
+ */
+export const executeSandboxCommand = async (command, options = {}) => {
+  const { timeoutSeconds = 15, sandbox = true, files = null } = options;
+
+  const response = await fetch(`${API_BASE_URL}/execute-command-sandbox`, {
+    method: 'POST',
+    mode: 'cors',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    },
+    body: JSON.stringify({
+      command,
+      timeout_seconds: timeoutSeconds,
+      sandbox,
+      files
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`API error: ${response.statusText}`);
+  }
+
+  return await response.json();
+};
+
+const extractShellCommands = (text = '') => {
+  const commands = [];
+  const blockRegex = /```(?:bash|sh|shell)\n([\s\S]*?)```/gi;
+  let match;
+
+  while ((match = blockRegex.exec(text)) !== null) {
+    const cmd = match[1].trim();
+    if (cmd) {
+      commands.push(cmd);
+    }
+  }
+
+  return commands;
+};
+
 /**
  * Autonomni ciklus: executor -> planner -> specijalizirani agent(i) -> executor sažetak.
  * @param {string} message
@@ -878,6 +926,35 @@ ORIGINALNI ZADATAK: ${message}`;
       response: stepResponse.response,
       plan_step: step
     });
+
+    const shellCommands = extractShellCommands(stepResponse.response);
+    for (const command of shellCommands) {
+      try {
+        const commandResult = await executeSandboxCommand(command, {
+          timeoutSeconds: options.timeoutSeconds || 20,
+          sandbox: options.sandbox !== false
+        });
+
+        log.push({
+          agent: 'sandbox-shell',
+          plan_step: step,
+          command,
+          command_result: commandResult
+        });
+      } catch (commandError) {
+        log.push({
+          agent: 'sandbox-shell',
+          plan_step: step,
+          command,
+          command_result: {
+            status: 'error',
+            stderr: commandError.message,
+            exit_code: 1,
+            stdout: ''
+          }
+        });
+      }
+    }
   }
 
   const summaryPrompt = `Na osnovu kompletnog dnevnika rada, vrati finalni odgovor korisniku.

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -835,7 +835,7 @@ export const getTokenUsageStats = async (sessionId = null) => {
  * @returns {Promise<Object>}
  */
 export const executeSandboxCommand = async (command, options = {}) => {
-  const { timeoutSeconds = 15, sandbox = true, files = null } = options;
+  const { timeoutSeconds = 15, sandbox = true, files = null, workspaceId = null, persistWorkspace = false } = options;
 
   const response = await fetch(`${API_BASE_URL}/execute-command-sandbox`, {
     method: 'POST',
@@ -848,8 +848,33 @@ export const executeSandboxCommand = async (command, options = {}) => {
       command,
       timeout_seconds: timeoutSeconds,
       sandbox,
-      files
+      files,
+      workspace_id: workspaceId,
+      persist_workspace: persistWorkspace
     }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`API error: ${response.statusText}`);
+  }
+
+  return await response.json();
+};
+
+
+
+/**
+ * Obriši persistent sandbox workspace.
+ * @param {string} workspaceId
+ * @returns {Promise<Object>}
+ */
+export const cleanupSandboxWorkspace = async (workspaceId) => {
+  const response = await fetch(`${API_BASE_URL}/sandbox-workspace/${workspaceId}`, {
+    method: 'DELETE',
+    mode: 'cors',
+    headers: {
+      'Accept': 'application/json'
+    }
   });
 
   if (!response.ok) {
@@ -883,6 +908,7 @@ const extractShellCommands = (text = '') => {
 export const executeAutonomousWorkflow = async (message, options = {}) => {
   const maxSteps = options.maxSteps || 3;
   const log = [];
+  let workspaceId = null;
 
   const executorResponse = await sendChatMessage(message, 'executor', { ...options });
   log.push({
@@ -932,8 +958,14 @@ ORIGINALNI ZADATAK: ${message}`;
       try {
         const commandResult = await executeSandboxCommand(command, {
           timeoutSeconds: options.timeoutSeconds || 20,
-          sandbox: options.sandbox !== false
+          sandbox: options.sandbox !== false,
+          workspaceId,
+          persistWorkspace: true
         });
+
+        if (commandResult.workspace_id) {
+          workspaceId = commandResult.workspace_id;
+        }
 
         log.push({
           agent: 'sandbox-shell',
@@ -969,6 +1001,19 @@ Originalni upit: ${message}`;
     response: summaryResponse.response,
     phase: 'summary'
   });
+
+  if (workspaceId) {
+    try {
+      await cleanupSandboxWorkspace(workspaceId);
+    } catch (cleanupError) {
+      log.push({
+        agent: 'sandbox-shell',
+        phase: 'workspace_cleanup',
+        workspace_id: workspaceId,
+        error: cleanupError.message
+      });
+    }
+  }
 
   return {
     mode: 'autonomous',

--- a/frontend/src/components/ChatBox.jsx
+++ b/frontend/src/components/ChatBox.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { sendChatMessage, executeWorkflow, getCurrentSessionId, resetSession, continueWorkflowExecution, getAvailableModels } from '../api';
+import { sendChatMessage, executeWorkflow, executeAutonomousWorkflow, getCurrentSessionId, resetSession, continueWorkflowExecution, getAvailableModels } from '../api';
 import Prism from 'prismjs';
 import 'prismjs/themes/prism-tomorrow.css';
 import 'prismjs/components/prism-javascript';
@@ -53,7 +53,7 @@ const ChatBox = ({ onResultChange, onWorkflowResult }) => {
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
   const [mcpServer, setMcpServer] = useState('anthropic');
   const [availableModels, setAvailableModels] = useState([]);
-  const [isWorkflowEnabled, setIsWorkflowEnabled] = useState(false);
+  const [autonomousMode, setAutonomousMode] = useState(false);
 
   // Provjeri aktivnu sesiju prilikom učitavanja
   useEffect(() => {
@@ -91,7 +91,8 @@ const ChatBox = ({ onResultChange, onWorkflowResult }) => {
     setSelectedAgent(localStorage.getItem('selectedAgent') || 'executor');
     setTemperature(parseFloat(localStorage.getItem('temperature') || '0.7'));
     setMcpServer(localStorage.getItem('mcpServer') || 'anthropic');
-    setIsWorkflowEnabled(localStorage.getItem('isWorkflowEnabled') === 'true');
+    setAutomaticWorkflow(localStorage.getItem('isWorkflowEnabled') === 'true' || localStorage.getItem('mcp_auto_workflow') === 'true');
+    setAutonomousMode(localStorage.getItem('autonomousMode') === 'true');
 
     // inicijalni session_id
     const sessionId = getCurrentSessionId();
@@ -111,8 +112,9 @@ const ChatBox = ({ onResultChange, onWorkflowResult }) => {
     localStorage.setItem('selectedAgent', selectedAgent);
     localStorage.setItem('temperature', temperature.toString());
     localStorage.setItem('mcpServer', mcpServer);
-    localStorage.setItem('isWorkflowEnabled', isWorkflowEnabled.toString());
-  }, [selectedModel, selectedAgent, temperature, mcpServer, isWorkflowEnabled]);
+    localStorage.setItem('isWorkflowEnabled', automaticWorkflow.toString());
+    localStorage.setItem('autonomousMode', autonomousMode.toString());
+  }, [selectedModel, selectedAgent, temperature, mcpServer, automaticWorkflow, autonomousMode]);
 
   // Scroll to bottom whenever chat history changes
   useEffect(() => {
@@ -175,8 +177,20 @@ const ChatBox = ({ onResultChange, onWorkflowResult }) => {
       
       let response;
       
-      // Izvršavanje pomoću workflow ili standardnog poziva
-      if (isWorkflowEnabled) {
+      // Izvršavanje pomoću autonomnog režima, workflow ili standardnog poziva
+      if (autonomousMode) {
+        response = await executeAutonomousWorkflow(message, { ...options, maxSteps: 3 });
+
+        const assistantMessage = {
+          id: Date.now().toString() + '-assistant',
+          role: 'assistant',
+          content: response.response,
+          autonomous: true,
+          workflowData: response
+        };
+
+        setChatHistory(prevMessages => [...prevMessages, assistantMessage]);
+      } else if (automaticWorkflow) {
         // Koristi workflow za automatsko generisanje i izvršavanje koda
         response = await executeWorkflow(message, handleWorkflowConfirmation, options);
         
@@ -329,6 +343,11 @@ const ChatBox = ({ onResultChange, onWorkflowResult }) => {
                   <div>
                     <div className="mb-1 text-xs text-gray-400 flex items-center">
                       <span className="capitalize mr-1">{chat.agent || chat.suggested_agent || 'Agent'}</span>
+                      {chat.autonomous && (
+                        <span className="bg-emerald-800 rounded-full px-2 py-0.5 text-xs ml-2">
+                          Autonomous
+                        </span>
+                      )}
                       {chat.workflow && (
                         <span className="bg-indigo-800 rounded-full px-2 py-0.5 text-xs ml-2">
                           Workflow
@@ -423,7 +442,7 @@ const ChatBox = ({ onResultChange, onWorkflowResult }) => {
               </div>
             </div>
             
-            <div className="mt-4 flex items-center">
+            <div className="mt-4 flex items-center justify-between gap-4 flex-wrap">
               <label className="flex items-center cursor-pointer">
                 <input 
                   type="checkbox" 
@@ -437,13 +456,21 @@ const ChatBox = ({ onResultChange, onWorkflowResult }) => {
                 <div className={`${automaticWorkflow ? 'bg-blue-600' : 'bg-gray-700'} relative inline-flex items-center h-6 rounded-full w-11 transition-colors`}>
                   <span className={`${automaticWorkflow ? 'translate-x-6' : 'translate-x-1'} inline-block w-4 h-4 transform bg-white rounded-full transition-transform`} />
                 </div>
-                <span className="ml-2 text-sm text-gray-300">Workflow Mod</span>
+                <span className="ml-2 text-sm text-gray-300">Workflow mod</span>
               </label>
-              <div className="ml-2">
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-gray-400 cursor-help" viewBox="0 0 20 20" fill="currentColor">
-                  <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5A1 1 0 1117 8a1 1 0 01.7 1.7l-3.467 3.467a1 1 0 01-.7.3H7.5a1 1 0 01-.5-2h2.167l3.53-3.53A1 1 0 0118 7a1 1 0 01-1 1h-1.7l-3.467 3.467A1 1 0 119 11a1 1 0 01-1-1v-1h-1v1a1 1 0 01-1 1H5a1 1 0 01-1-1v-2a1 1 0 011-1h2a1 1 0 111 1v1h1V8a1 1 0 01.5-.867A1 1 0 0110 7z" clipRule="evenodd" />
-                </svg>
-              </div>
+
+              <label className="flex items-center cursor-pointer">
+                <input 
+                  type="checkbox" 
+                  checked={autonomousMode}
+                  onChange={() => setAutonomousMode(!autonomousMode)}
+                  className="sr-only"
+                />
+                <div className={`${autonomousMode ? 'bg-emerald-600' : 'bg-gray-700'} relative inline-flex items-center h-6 rounded-full w-11 transition-colors`}>
+                  <span className={`${autonomousMode ? 'translate-x-6' : 'translate-x-1'} inline-block w-4 h-4 transform bg-white rounded-full transition-transform`} />
+                </div>
+                <span className="ml-2 text-sm text-gray-300">Autonomni režim</span>
+              </label>
             </div>
           </div>
         )}
@@ -467,8 +494,8 @@ const ChatBox = ({ onResultChange, onWorkflowResult }) => {
             
             {uploadedImages.map((image, index) => (
               <div key={`image-${index}`} className="bg-gray-700 rounded-lg px-3 py-1 flex items-center text-sm">
-                <img src={URL.createObjectURL(image)} alt="Preview" className="h-5 w-5 object-cover mr-2 rounded" />
-                <span className="mr-2">{image.name}</span>
+                <img src={image.preview} alt="Preview" className="h-5 w-5 object-cover mr-2 rounded" />
+                <span className="mr-2">{image.file.name}</span>
                 <button
                   onClick={() => handleRemoveImage(index)}
                   className="text-gray-400 hover:text-gray-200"
@@ -585,20 +612,9 @@ const ChatBox = ({ onResultChange, onWorkflowResult }) => {
             )}
           </div>
           
-          <div className="flex items-center">
-            <div className="settings-group">
-              <label>
-                <input
-                  type="checkbox"
-                  checked={isWorkflowEnabled}
-                  onChange={(e) => {
-                    setIsWorkflowEnabled(e.target.checked);
-                    localStorage.setItem('isWorkflowEnabled', e.target.checked.toString());
-                  }}
-                />
-                Workflow Mode
-              </label>
-            </div>
+          <div className="flex items-center gap-3">
+            {automaticWorkflow && <span className="text-blue-400">Workflow uključen</span>}
+            {autonomousMode && <span className="text-emerald-400">Autonomni režim aktivan</span>}
           </div>
         </div>
       </div>

--- a/frontend/src/components/ChatBox.jsx
+++ b/frontend/src/components/ChatBox.jsx
@@ -303,27 +303,32 @@ const ChatBox = ({ onResultChange, onWorkflowResult }) => {
             </div>
           </div>
         ) : (
-          chatHistory.map((chat, index) => (
+          chatHistory.map((chat, index) => {
+            const messageRole = chat.role || chat.type;
+            const messageText = chat.content || chat.text;
+            const messageKey = chat.id || `${messageRole || 'message'}-${index}`;
+
+            return (
             <div 
-              key={index} 
-              className={`flex ${chat.type === 'user' ? 'justify-end' : 'justify-start'}`}
+              key={messageKey} 
+              className={`flex ${messageRole === 'user' ? 'justify-end' : 'justify-start'}`}
             >
               <div 
                 className={`max-w-3/4 rounded-lg p-4 ${
-                  chat.type === 'user' 
+                  messageRole === 'user' 
                     ? 'bg-blue-600 text-white' 
                     : 'bg-gray-800 text-gray-100'
                 }`}
               >
-                {chat.type === 'user' ? (
+                {messageRole === 'user' ? (
                   <div>
                     <div className="mb-1 text-xs text-blue-200 opacity-75">Vi</div>
-                    <div>{chat.text}</div>
+                    <div>{messageText}</div>
                   </div>
                 ) : (
                   <div>
                     <div className="mb-1 text-xs text-gray-400 flex items-center">
-                      <span className="capitalize mr-1">{chat.agent || 'Agent'}</span>
+                      <span className="capitalize mr-1">{chat.agent || chat.suggested_agent || 'Agent'}</span>
                       {chat.workflow && (
                         <span className="bg-indigo-800 rounded-full px-2 py-0.5 text-xs ml-2">
                           Workflow
@@ -333,14 +338,15 @@ const ChatBox = ({ onResultChange, onWorkflowResult }) => {
                     <div 
                       className="prose prose-invert max-w-none"
                       dangerouslySetInnerHTML={{
-                        __html: formatCodeBlocks(chat.text)
+                        __html: formatCodeBlocks(messageText)
                       }}
                     />
                   </div>
                 )}
               </div>
             </div>
-          ))
+          );
+          })
         )}
         
         {isLoading && (

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
-    open: true
+    open: false
   }
 })


### PR DESCRIPTION
### Motivation

- Eliminate recurring React list-key and rendering warnings coming from chat messages with mixed shapes and from index-based keys. 
- Prevent Vite dev server startup errors in headless environments caused by `xdg-open` being unavailable. 
- Improve UI robustness by using a better assistant-label fallback when messages include `suggested_agent`.

### Description

- Updated `frontend/src/components/ChatBox.jsx` to consistently read messages using `role`/`content` with fallbacks to legacy `type`/`text`. 
- Replaced index-based list keys with stable keys using `chat.id` or a deterministic fallback (`${messageRole || 'message'}-${index}`) to stop React key warnings. 
- Switched displayed text to use the normalized `messageText` and added `chat.suggested_agent` to the assistant label fallback. 
- Updated `frontend/vite.config.js` to set `server.open` to `false` so Vite doesn't attempt to open a browser (avoiding `spawn xdg-open ENOENT` in headless CI/dev).

### Testing

- Ran `cd frontend && npm run build` and the frontend build completed successfully. 
- Launched the frontend dev server and ran a Playwright script to capture a screenshot of the rendered chat UI, which completed and produced an artifact. 
- Attempted backend tests with `python -m pytest` but they failed due to a missing `requirements.txt` in the backend invocation environment. 
- Noted that `npm` still prints an external environment warning `Unknown env config "http-proxy"`, which is caused by global environment npm config and is not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a368a0d76c8332b6b50fba677e860f)